### PR TITLE
Release/v1.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.16.3)
 # ===================================================================
 #      PROJECT SETUP
 # ===================================================================
-project(flexiv_tdk VERSION 1.2.2)
+project(flexiv_tdk VERSION 1.3)
 
 # Configure build type
 if(NOT CMAKE_BUILD_TYPE)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Flexiv TDK
 
-![CMake Badge](https://github.com/flexivrobotics/flexiv_tdk/actions/workflows/cmake.yml/badge.svg) ![Version](https://img.shields.io/badge/version-1.1-blue.svg) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
+![CMake Badge](https://github.com/flexivrobotics/flexiv_tdk/actions/workflows/cmake.yml/badge.svg) ![Version](https://img.shields.io/badge/version-1.3-blue.svg) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
 
 Flexiv TDK (Teleoperation Development Kit) is an SDK for developing customized robot-robot or device-robot teleoperation applications with Flexiv's adaptive robots. It features synchronized motions that are force-guided using high-fidelity perceptual feedback and supports both LAN (Local Area Network) and WAN (Wide Area Network, i.e. Internet) connections.
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 
 # Example list
 set(EXAMPLE_LIST
+  high_transparency_teleop
   cartesian_teleop_under_lan
   joint_teleop_over_wan
   joint_teleop_under_lan

--- a/example/high_transparency_teleop.cpp
+++ b/example/high_transparency_teleop.cpp
@@ -1,0 +1,214 @@
+/**
+ * @file high_transparency_teleop.cpp
+ * @copyright Copyright (C) 2016-2025 Flexiv Ltd. All Rights Reserved.
+ */
+
+// Flexiv
+#include <atomic>
+#include <chrono>
+#include <spdlog/spdlog.h>
+#include <flexiv/tdk/transparent_cartesian_teleop_lan.hpp>
+#include <flexiv/tdk/data.hpp>
+#include <getopt.h>
+#include <iostream>
+#include <thread>
+namespace {
+std::vector<double> kPreferredJntPos
+    = {60 * M_PI / 180.0, -60 * M_PI / 180.0, -85 * M_PI / 180.0, 115 * M_PI / 180.0,
+        70 * M_PI / 180.0, 0 * M_PI / 180.0, 0 * M_PI / 180.0}; ///< Preferred joint position
+std::vector<double> kHomeJntPos
+    = {0 * M_PI / 180.0, -40 * M_PI / 180.0, 0 * M_PI / 180.0, 90 * M_PI / 180.0, 0 * M_PI / 180.0,
+        40 * M_PI / 180.0, 0 * M_PI / 180.0}; ///< Preferred joint position
+
+const std::array<double, flexiv::tdk::kCartDoF> kDefaultMaxContactWrench
+    = {5.0, 5.0, 5.0, 40.0, 40.0, 40.0}; ///< Maximum contact wrench
+
+std::atomic<bool> g_stop_sched = {false}; ///< Atomic signal to stop scheduler tasks
+} // namespace
+
+void printHelp()
+{
+    // clang-format off
+    spdlog::error("Invalid program arguments");
+    spdlog::info("     -l     [necessary] serial number of local robot.");
+    spdlog::info("     -r     [necessary] serial number of remote robot.");
+    spdlog::info("Usage: ./cart_teleop -l Rizon4s-123456 -r Rizon4s-654321 ");
+    // clang-format on
+}
+
+struct option kLongOptions[] = {
+    // clang-format off
+    {"local SN",               required_argument,  0, 'l'},
+    {"remote SN",              required_argument,  0, 'r'},
+    {0,                      0,                    0,  0 }
+    // clang-format on
+};
+
+/**
+ * @brief function for test
+ */
+void ConsoleTask(flexiv::tdk::TransparentCartesianTeleopLAN& teleop)
+{
+    unsigned int index = 0;
+    flexiv::tdk::AxisLock cmd;
+    teleop.GetAxisLockState(index, cmd);
+
+    while (!teleop.any_fault()) {
+
+        std::string userInput;
+        std::getline(std::cin, userInput);
+
+        switch (userInput[0]) {
+            case 'x':
+                cmd.lock_trans_axis[0] = !cmd.lock_trans_axis[0];
+                cmd.coord = flexiv::tdk::CoordType::COORD_WORLD;
+                break;
+            case 'y':
+                cmd.lock_trans_axis[1] = !cmd.lock_trans_axis[1];
+                cmd.coord = flexiv::tdk::CoordType::COORD_WORLD;
+                break;
+            case 'z':
+                cmd.lock_trans_axis[2] = !cmd.lock_trans_axis[2];
+                cmd.coord = flexiv::tdk::CoordType::COORD_WORLD;
+                break;
+            case 'q':
+                cmd.lock_ori_axis[0] = !cmd.lock_ori_axis[0];
+                cmd.coord = flexiv::tdk::CoordType::COORD_WORLD;
+                break;
+            case 'w':
+                cmd.lock_ori_axis[1] = !cmd.lock_ori_axis[1];
+                cmd.coord = flexiv::tdk::CoordType::COORD_WORLD;
+                break;
+            case 'e':
+                cmd.lock_ori_axis[2] = !cmd.lock_ori_axis[2];
+                cmd.coord = flexiv::tdk::CoordType::COORD_WORLD;
+                break;
+
+            case 'X':
+                cmd.lock_trans_axis[0] = !cmd.lock_trans_axis[0];
+                cmd.coord = flexiv::tdk::CoordType::COORD_TCP;
+                break;
+            case 'Y':
+                cmd.lock_trans_axis[1] = !cmd.lock_trans_axis[1];
+                cmd.coord = flexiv::tdk::CoordType::COORD_TCP;
+                break;
+            case 'Z':
+                cmd.lock_trans_axis[2] = !cmd.lock_trans_axis[2];
+                cmd.coord = flexiv::tdk::CoordType::COORD_TCP;
+                break;
+            case 'Q':
+                cmd.lock_ori_axis[0] = !cmd.lock_ori_axis[0];
+                cmd.coord = flexiv::tdk::CoordType::COORD_TCP;
+                break;
+            case 'W':
+                cmd.lock_ori_axis[1] = !cmd.lock_ori_axis[1];
+                cmd.coord = flexiv::tdk::CoordType::COORD_TCP;
+                break;
+            case 'E':
+                cmd.lock_ori_axis[2] = !cmd.lock_ori_axis[2];
+                cmd.coord = flexiv::tdk::CoordType::COORD_TCP;
+                break;
+            case 'r':
+                teleop.Engage(index, true);
+                break;
+            case 'R':
+                teleop.Engage(index, false);
+                break;
+            case 's':
+                cmd.lock_ori_axis = {false, false, false};
+                cmd.lock_trans_axis = {false, false, false};
+                cmd.coord = flexiv::tdk::CoordType::COORD_TCP;
+                break;
+            case 'S':
+                cmd.lock_ori_axis = {true, true, true};
+                cmd.lock_trans_axis = {true, true, true};
+                cmd.coord = flexiv::tdk::CoordType::COORD_TCP;
+                break;
+            case 't':
+                teleop.SetRepulsiveForce(index, {5, 0, 0});
+                break;
+            case 'T':
+                teleop.SetWrenchFeedbackScalingFactor(index, 1.5);
+                break;
+            case 'i':
+                teleop.SetLocalNullSpacePosture(index, kPreferredJntPos);
+                break;
+            case 'I':
+                teleop.SetLocalNullSpacePosture(index, kHomeJntPos);
+                break;
+            case 'o':
+                teleop.SetRemoteNullSpacePosture(index, kPreferredJntPos);
+                break;
+            case 'O':
+                teleop.SetRemoteNullSpacePosture(index, kHomeJntPos);
+                break;
+            case 'p':
+                teleop.SetRemoteMaxContactWrench(index, kDefaultMaxContactWrench);
+                break;
+            case 'L':
+                teleop.robot_states(0);
+                break;
+            case 'k':
+                teleop.digital_inputs(0);
+                break;
+
+            default:
+                spdlog::warn("Invalid command!");
+                break;
+        }
+        teleop.SetAxisLockCmd(index, cmd);
+    }
+    return;
+}
+
+int main(int argc, char* argv[])
+{
+    std::string remote_sn;
+    std::string local_sn;
+    int opt = 0;
+    int longIndex = 0;
+    while ((opt = getopt_long_only(argc, argv, "", kLongOptions, &longIndex)) != -1) {
+        switch (opt) {
+            case 'r':
+                remote_sn = std::string(optarg);
+                break;
+            case 'l':
+                local_sn = std::string(optarg);
+                break;
+            default:
+                printHelp();
+                return 1;
+        }
+    }
+    if (local_sn.empty() || remote_sn.empty()) {
+        printHelp();
+        return 1;
+    }
+
+    try {
+
+        // Allocate tdk object
+        flexiv::tdk::TransparentCartesianTeleopLAN htt({{local_sn, remote_sn}});
+
+        // Init high transparency teleop
+        htt.Init();
+
+        // Start high transparency teleop
+        htt.Start();
+
+        // Helper thread
+        std::thread helper_thread(std::bind(ConsoleTask, std::ref(htt)));
+
+        // Block main with helper thead
+        helper_thread.join();
+
+        // Exit high transparency teleop
+        htt.Stop();
+
+    } catch (const std::exception& e) {
+        spdlog::error(e.what());
+        return 1;
+    }
+
+    return 0;
+}

--- a/include/flexiv/tdk/cartesian_teleop_lan.hpp
+++ b/include/flexiv/tdk/cartesian_teleop_lan.hpp
@@ -1,6 +1,6 @@
 /**
  * @file cartesian_teleop_lan.hpp
- * @copyright Copyright (C) 2016-2024 Flexiv Ltd. All Rights Reserved.
+ * @copyright Copyright (C) 2016-2025 Flexiv Ltd. All Rights Reserved.
  */
 #pragma once
 

--- a/include/flexiv/tdk/data.hpp
+++ b/include/flexiv/tdk/data.hpp
@@ -1,7 +1,7 @@
 /**
  * @file data.hpp
  * @brief Header file containing various constant expressions, data structs, and enums.
- * @copyright Copyright (C) 2016-2024 Flexiv Ltd. All Rights Reserved.
+ * @copyright Copyright (C) 2016-2025 Flexiv Ltd. All Rights Reserved.
  */
 
 #pragma once
@@ -9,6 +9,7 @@
 #include <array>
 #include <vector>
 #include <cstddef>
+#include <string>
 
 namespace flexiv {
 namespace tdk {
@@ -20,6 +21,60 @@ constexpr size_t kPoseSize = 7;
 
 /** Number of digital IO ports (16 on control box + 2 inside the wrist connector) */
 constexpr size_t kIOPorts = 18;
+
+/** Max wrench feedback scaling factor for high transparency teleop*/
+constexpr double kMaxWrenchFeedbackScale = 3;
+
+/**
+ * @brief Reference coordinate that the axis to be locked
+ */
+enum CoordType
+{
+    COORD_UNKNOWN = 0, ///> Unknown coordinate
+    COORD_TCP,         ///> TCP coordinate of local robot
+    COORD_WORLD        ///> WORLD coordinate of local robot
+};
+
+static const std::string CoordTypeStr[] = {"UNKNOWN", "TCP", "WORLD"};
+
+/**
+ * @brief Get the coordinate type of axis locking status
+ * @param[in] str string name of the coordinate
+ * @return CoordType
+ */
+static inline CoordType GetCoordType(const std::string& str)
+{
+    for (size_t i = 0; i < COORD_WORLD - COORD_UNKNOWN + 1; i++) {
+        if (str == CoordTypeStr[i]) {
+            return static_cast<CoordType>(i);
+        }
+    }
+    return COORD_UNKNOWN;
+}
+
+/**
+ * @brief Data for locking axis, including reference frame and axis to be locked.
+ * Coordinate type options are: "COORD_TCP" for TCP frame and "COORD_WORLD" for WORLD frame.
+ */
+struct AxisLock
+{
+    /**
+     * @brief Reference coordinate that the axis to be locked
+     */
+    CoordType coord = CoordType::COORD_UNKNOWN;
+
+    /**
+     * @brief Translation axis lock, the corresponding axis order is \f$ [X, Y, Z] \f$. True
+     * for locking, false for floating.
+     */
+    std::array<bool, 3> lock_trans_axis = {false, false, false};
+
+    /**
+     * @brief Orientation axis lock, the corresponding axis order is \f$ [Rx, Ry, Rz] \f$.
+     * True for locking, false for floating.
+     */
+    std::array<bool, 3> lock_ori_axis = {false, false, false};
+};
 
 /**
  * @struct RobotStates
@@ -108,13 +163,6 @@ struct RobotStates
     std::array<double, kPoseSize> tcp_pose = {};
 
     /**
-     * Desired TCP pose expressed in world frame: \f$ {^{O}T_{TCP}}_{d} \in \mathbb{R}^{7 \times 1}
-     * \f$. Consists of \f$ \mathbb{R}^{3 \times 1} \f$ position and \f$ \mathbb{R}^{4 \times 1} \f$
-     * quaternion: \f$ [x, y, z, q_w, q_x, q_y, q_z]^T \f$. Unit: \f$ [m]:[] \f$.
-     */
-    std::array<double, kPoseSize> tcp_pose_des = {};
-
-    /**
      * Measured TCP velocity expressed in world frame: \f$ ^{O}\dot{X} \in \mathbb{R}^{6 \times 1}
      * \f$. Consists of \f$ \mathbb{R}^{3 \times 1} \f$ linear velocity and \f$ \mathbb{R}^{3 \times
      * 1} \f$ angular velocity: \f$ [v_x, v_y, v_z, \omega_x, \omega_y, \omega_z]^T \f$.
@@ -164,5 +212,5 @@ struct RobotStates
     std::array<double, kCartDoF> ext_wrench_in_world_raw = {};
 };
 
-} /* namespace tdk */
-} /* namespace flexiv */
+} // namespace tdk
+} // namespace flexiv

--- a/include/flexiv/tdk/joint_teleop_lan.hpp
+++ b/include/flexiv/tdk/joint_teleop_lan.hpp
@@ -1,6 +1,6 @@
 /**
  * @file joint_teleop_lan.hpp
- * @copyright Copyright (C) 2016-2024 Flexiv Ltd. All Rights Reserved.
+ * @copyright Copyright (C) 2016-2025 Flexiv Ltd. All Rights Reserved.
  */
 #pragma once
 

--- a/include/flexiv/tdk/joint_teleop_wan.hpp
+++ b/include/flexiv/tdk/joint_teleop_wan.hpp
@@ -1,6 +1,6 @@
 /**
  * @file joint_teleop_wan.hpp
- * @copyright Copyright (C) 2016-2024 Flexiv Ltd. All Rights Reserved.
+ * @copyright Copyright (C) 2016-2025 Flexiv Ltd. All Rights Reserved.
  */
 #pragma once
 

--- a/include/flexiv/tdk/transparent_cartesian_teleop_lan.hpp
+++ b/include/flexiv/tdk/transparent_cartesian_teleop_lan.hpp
@@ -1,0 +1,287 @@
+/**
+ * @file transparent_cartesian_teleop_lan.hpp
+ * @copyright Copyright (C) 2016-2025 Flexiv Ltd. All Rights Reserved.
+ */
+#pragma once
+
+#include "data.hpp"
+#include <string>
+#include <memory>
+
+namespace flexiv {
+namespace tdk {
+
+/**
+ * @brief Teleoperation control interface to run Cartesian-space Rizon4s-Rizon4s teleoperation for
+ * one or more pairs of robots connected to the same LAN.  It performs synchronized, force guided
+ * real-time motions and provide the operator with high-fidelity haptic feedback.
+ */
+class TransparentCartesianTeleopLAN
+{
+public:
+    /**
+     * @brief [Blocking] Create an instance of the control interface. More than one pair of
+     * teleoperated robots can be controlled at the same time, see parameter [robot_pairs_sn].
+     * @param[in] robot_pairs_sn Serial number of all robot pairs to run teleoperation on. Each pair
+     * in the vector represents a pair of bilaterally teleoperated robots. For example, provide 2
+     * pairs of robot serial numbers to start a dual-arm teleoperation that involves 2 pairs of
+     * robots. The accepted formats are: "Rizon 4s-123456" and "Rizon4s-123456". In each pair, the
+     * first robot is referred to as the "local robot", which interacts with human hands. The second
+     * robot is referred to as the "remote robot", which interacts with the workpiece.
+     * @param[in] network_interface_whitelist Limit the network interface(s) that can be used to try
+     * to establish connection with the specified robot. The whitelisted network interface is
+     * defined by its associated IPv4 address. For example, {"10.42.0.1", "192.168.2.102"}. If left
+     * empty, all available network interfaces will be tried when searching for the specified robot.
+     * @throw std::invalid_argument if the format of any element in [robot_pairs_sn] is invalid; or
+     * the size of [robot_pairs_sn] exceeds the allowed number.
+     * @throw std::runtime_error if error occurred during construction.
+     * @throw std::logic_error if one of the connected robots does not have a valid TDK license; or
+     * the version of this TDK library is incompatible with one of the connected robots; or model of
+     * any connected robot is not supported.
+     * @warning This constructor blocks until the initialization sequence is successfully finished
+     * and connection with all robots is established.
+     */
+    TransparentCartesianTeleopLAN(
+        const std::vector<std::pair<std::string, std::string>>& robot_pairs_sn,
+        const std::vector<std::string>& network_interface_whitelist = {});
+    virtual ~TransparentCartesianTeleopLAN();
+
+    /**
+     * @brief [Blocking] Get all robots ready for teleoperation. The following actions will
+     * happen in sequence: a) enable robot, b) zero force/torque sensors.
+     * @throw std::runtime_error if the initialization sequence failed.
+     * @note This function blocks until the initialization sequence is finished.
+     * @warning This process involves sensor zeroing, please make sure the robot is not in contact
+     * with anything during the process.
+     */
+    void Init();
+
+    /**
+     * @brief [Blocking] Start the teleoperation control loop.
+     * @throw std::runtime_error if failed to start the teleoperation control loop.
+     * @throw std::logic_error if initialization sequence hasn't been triggered yet using Init().
+     * @note This function blocks until the control loop has started running. The user might need to
+     * implement further blocking after this function returns.
+     * @note None of the teleoperation participants will move until both sides are started.
+     */
+    void Start();
+
+    /**
+     * @brief [Blocking] Stop the teleoperation control loop and make all robots hold their pose.
+     * @throw std::runtime_error if failed to stop the teleoperation control loop.
+     * @note This function blocks until the control loop has stopped running and all robots in hold.
+     * @note If you do NOT want to stop the control loop but temporarily pause the teleop, you can
+     * lock/unlock all the axes, which is non-blocking. See SetAxisLockCmd.
+     */
+    void Stop();
+
+    /**
+     * @brief [Non-blocking] Engage/disengage the local and remote robot.
+     * TransparentCartesianTeleopLAN supports teleop local and remote robots in different
+     * configurations. When disengaged, the operators can move the local robot to the center of the
+     * workspace or re-orientated for better ergonomics. Meanwhile, the remote robot will remain
+     * stationary. When engaged again, the remote robot will only mimics the local's relative motion
+     * instead of simply mirroring the pose.
+     * @param[in] idx Index of the robot pair to set flag for. This index is the same as the index
+     * of the constructor parameter [robot_pairs_sn].
+     * @param[in] engaged True to engage the teleop, false to disengage.
+     * @note The teleop will keep disengaged by default.
+     */
+    void Engage(unsigned int idx, bool engaged);
+
+    /**
+     * @brief [Blocking] Set reference joint positions used in the robot's null-space posture
+     * control module for the specified local robot. By "local robot" we mean the first robot in
+     * [robot_pairs_sn], which interacts with human hands. Call this only after Start() is
+     * triggered.
+     * @param[in] idx Index of the robot pair to set null-space posture for. This index is the same
+     * as the index of the constructor parameter [robot_pairs_sn].
+     * @param[in] ref_positions Reference joint positions for the null-space posture control of both
+     * robots in the pair: \f$ q_{ns} \in \mathbb{R}^{n \times 1} \f$. Unit: \f$ [rad] \f$.
+     * @throw std::invalid_argument if [idx] exceeds total number of robot pairs.
+     * @throw std::invalid_argument if [ref_joint_positions] contains any value outside joint limits
+     * or size of input vector does not match robot DoF.
+     * @throw std::logic_error if the teleoperation control loop is not started.
+     * @throw std::runtime_error if failed to deliver the request to the connected robots.
+     * @note This function blocks until the request is successfully delivered.
+     * @par Null-space posture control
+     * Similar to human arm, a robotic arm with redundant joint-space degree(s) of freedom (DoF > 6)
+     * can change its overall posture without affecting the ongoing primary task. This is achieved
+     * through a technique called "null-space control". After the reference joint positions of a
+     * desired robot posture are set using this function, the robot's null-space control module will
+     * try to pull the arm as close to this posture as possible without affecting the primary
+     * Cartesian motion-force control task.
+     */
+    void SetLocalNullSpacePosture(unsigned int idx, const std::vector<double>& ref_joint_positions);
+
+    /**
+     * @brief [Blocking] Set reference joint positions used in the robot's null-space posture
+     * control module for the specified remote robot. By "remote robot" we mean the second robot in
+     * [robot_pairs_sn], which interacts with workpiece. Call this only after Start() is
+     * triggered.
+     * @param[in] idx Index of the robot pair to set null-space posture for. This index is the same
+     * as the index of the constructor parameter [robot_pairs_sn].
+     * @param[in] ref_positions Reference joint positions for the null-space posture control of both
+     * robots in the pair: \f$ q_{ns} \in \mathbb{R}^{n \times 1} \f$. Unit: \f$ [rad] \f$.
+     * @throw std::invalid_argument if [idx] exceeds total number of robot pairs.
+     * @throw std::invalid_argument if [ref_joint_positions] contains any value outside joint limits
+     * or size of input vector does not match robot DoF.
+     * @throw std::logic_error if the teleoperation control loop is not started.
+     * @throw std::runtime_error if failed to deliver the request to the connected robots.
+     * @note This function blocks until the request is successfully delivered.
+     * @par Null-space posture control
+     * Similar to human arm, a robotic arm with redundant joint-space degree(s) of freedom (DoF > 6)
+     * can change its overall posture without affecting the ongoing primary task. This is achieved
+     * through a technique called "null-space control". After the reference joint positions of a
+     * desired robot posture are set using this function, the robot's null-space control module will
+     * try to pull the arm as close to this posture as possible without affecting the primary
+     * Cartesian motion-force control task.
+     */
+    void SetRemoteNullSpacePosture(
+        unsigned int idx, const std::vector<double>& ref_joint_positions);
+
+    /**
+     * @brief [Non-blocking] Robot states of the specified robot pair.
+     * @param[in] idx Index of the robot pair to get states for. This index is the same as the
+     * index of the constructor parameter [robot_pairs_sn].
+     * @return RobotStates value copy of the first and second robot respectively in the robot pair.
+     * @throw std::invalid_argument if [idx] exceeds total number of robot pairs.
+     */
+    const std::pair<RobotStates, RobotStates> robot_states(unsigned int idx) const;
+
+    /**
+     * @brief [Non-blocking] Fault state of the specified robot pair.
+     * @param[in] idx Index of the robot pair to get fault state for. This index is the same as the
+     * index of the constructor parameter [robot_pairs_sn].
+     * @return Fault state of the first and second robot respectively in the robot pair. True: has
+     * fault; false: no fault.
+     * @throw std::invalid_argument if [idx] exceeds total number of robot pairs.
+     */
+    const std::pair<bool, bool> fault(unsigned int idx) const;
+
+    /**
+     * @brief [Non-blocking] Whether any of the connected robots is in fault state.
+     * @return True: at least one robot has fault; false: none has fault.
+     */
+    bool any_fault(void) const;
+
+    /**
+     * @brief [Blocking] Try to clear minor or critical fault of the robot without a power cycle.
+     * @param[in] timeout_sec Maximum time in seconds to wait for the fault to be successfully
+     * cleared. Normally, a minor fault should take no more than 3 seconds to clear, and a critical
+     * fault should take no more than 30 seconds to clear.
+     * @return True: successfully cleared fault; false: failed to clear fault.
+     * @return For each element in the pair vector, true: successfully cleared fault or no fault for
+     * this robot, false: failed to clear fault for this robot. The pattern of the pair vector is
+     * the same as the constructor parameter [robot_pairs_sn].
+     * @throw std::runtime_error if failed to deliver the request to the connected robot.
+     * @note This function blocks until the fault is successfully cleared or [timeout_sec] has
+     * elapsed.
+     * @warning Clearing a critical fault through this function without a power cycle requires a
+     * dedicated device, which may not be installed in older robot models.
+     */
+    std::vector<std::pair<bool, bool>> ClearFault(unsigned int timeout_sec = 30);
+
+    /**
+     * @brief [Non-blocking] Current reading from all digital input ports (16 on the control box + 2
+     * inside the wrist connector) of the specified robot pair.
+     * @param[in] idx Index of the robot pair to read from. This index is the same as the index
+     * of the constructor parameter [robot_pairs_sn].
+     * @return A pair of boolean arrays whose index corresponds to that of the digital input ports
+     * of the corresponding robot in the pair. True: port high; false: port low.
+     * @throw std::invalid_argument if [idx] exceeds total number of robot pairs.
+     */
+    const std::pair<std::array<bool, kIOPorts>, std::array<bool, kIOPorts>> digital_inputs(
+        unsigned int idx) const;
+
+    /**
+     * @brief [Non-blocking] Set maximum contact wrench for the remote robot of specified robot
+     * pair. The controller will regulate its output to maintain contact wrench (force and moment)
+     * with the environment under the set values.
+     * @param[in] idx Index of the robot pair to read from. This index is the same as the index
+     * of the constructor parameter [robot_pairs_sn].
+     * @param[in] max_wrench Maximum contact wrench (force and moment): \f$ F_max \in \mathbb{R}^{6
+     * \times 1} \f$. Consists of \f$ \mathbb{R}^{3 \times 1} \f$ maximum force and \f$
+     * \mathbb{R}^{3 \times 1} \f$ maximum moment: \f$ [f_x, f_y, f_z, m_x, m_y, m_z]^T \f$. Unit:
+     * \f$ [N]~[Nm] \f$.
+     * @throw std::invalid_argument if [max_wrench] contains any negative value.
+     * @throw std::logic_error if teleop is not initialized.
+     */
+    void SetRemoteMaxContactWrench(
+        unsigned int idx, const std::array<double, kCartDoF>& max_wrench);
+
+    /**
+     * @brief [Non-blocking] Set the repulsive force in World or Tcp frame of the remote robot.
+     * @param[in] idx Index of the robot pair to set for. This index is the same as the
+     * index of the constructor parameter [robot_pairs_sn].
+     * @param[in] repulsive_force The virtual repulsive force that will applied on the remote
+     * robot in the specified robot pair [idx].: \f$ repulsiveF \in \mathbb{R}^{3 \times 1} \f$.
+     * Consists of \f$ \mathbb{R}^{3 \times 1} \f$ repulsive force : \f$ [f_x, f_y, f_z]^T \f$.
+     * Unit: \f$ [N] \f$.
+     *  @param[in] in_world Flag to indicate that the repulsive force is in World frame or Tcp
+     * frame. true in World frame, false in Tcp frame.
+     * @note This virtual repulsive wrench will only work on those unlocked axis, and will be
+     * ignored if the manipulability is not good enough.
+     * @warning Overlarge or discontinuous force can cause the robot to report errors. Please use
+     * this interface carefully. To use this API, users should possess robot programming
+     * capabilities.
+     * @see SetLocalAxisLockCmd
+     * @see GetLocalAxisLockState
+     */
+    void SetRepulsiveForce(
+        unsigned int idx, const std::array<double, 3>& repulsive_force, bool in_world = true);
+
+    /**
+     * @brief[Non-blocking] Set the wrench feedback scaling factor.
+     * @param[in] idx Index of the robot pair to set for. This index is the same as the
+     * index of the constructor parameter [robot_pairs_sn].
+     * @param[in] factor This coefficient will scale the feedback wrench of the remote robot.
+     * Scale factor greater than 1 means that the external force received by the remote robot is
+     * amplified, otherwise it will be reduce. Setting scale to zero means no wrench feedback
+     * and 1 means 100% transparency. Valid range: [0, kMaxWrenchFeedbackScale]
+     * @throw std::invalid_argument if input scale is outside the valid range.
+     * @warning Only when the user ensures that the interaction force between the remote robot
+     * and workpiece is very small, such as when operating a very soft object, do they need to
+     * set the factor to be greater than 1. Or to use [SetRemoteMaxContactWrench] to limit the
+     * maximum contact wrench. If the object in contact with the remote robot has high stiffness,
+     * please set the factor very carefully. The higher the scale, the greater the force feedback to
+     * the local robot will be. Using a scaling factor of 1 is recommended.
+     * @see SetRemoteMaxContactWrench
+     * @see kMaxWrenchFeedbackScale
+     */
+    void SetWrenchFeedbackScalingFactor(unsigned int idx, double factor = 1.0);
+
+    /**
+     * @brief [Non-blocking] Set the local robot axis locking command.
+     * @param[in] idx Index of the robot pair to set commands for. This index is the same as the
+     * index of the constructor parameter [robot_pairs_sn].
+     * @param[in] cmd User input command to lock the motion of the specified axis in the reference
+     * coordinate.
+     */
+    void SetAxisLockCmd(unsigned int idx, const AxisLock& cmd);
+
+    /**
+     * @brief [Non-blocking] Get the local robot axis locking status
+     * @param[in] idx Index of the robot pair to get state for. This index is the same as the
+     * index of the constructor parameter [robot_pairs_sn].
+     * @param[out] data Current axis locking state of local robot.
+     */
+    void GetAxisLockState(unsigned int idx, AxisLock& data);
+
+    /**
+     * @brief [Non-blocking] Get the local robot axis locking status
+     * @param[in] idx Index of the robot pair to get states for. This index is the same as the
+     * index of the constructor parameter [robot_pairs_sn].
+     * @warning This fuction is less efficient than the other overloaded one as additional runtime
+     * memory allocation and data copying are performed.
+     * @return AxisLock
+     */
+    AxisLock GetAxisLockState(unsigned int idx);
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> pimpl_;
+};
+
+} // namespace tdk
+} // namespace flexiv


### PR DESCRIPTION
- Update version to v1.3
- Revert `Robot2RobotTeleop` in V1.1 back and rename it to `TransparentCartesianTeleopLAN`
- Refactor the `TransparentCartesianTeleopLAN` class API to make it unified
- Wrench feedback transparency improvement